### PR TITLE
handle double col type

### DIFF
--- a/generic/generic.go
+++ b/generic/generic.go
@@ -96,6 +96,8 @@ func (a Adapter) GetColumnTypeDefinition(col *message.ColumnMetaData) *internal.
 		column.Rep = message.Rep_BIG_DECIMAL
 	case "FLOAT", "REAL":
 		column.Rep = message.Rep_FLOAT
+	case "DOUBLE":
+		column.Rep = message.Rep_DOUBLE
 	case "TIME":
 		column.Rep = message.Rep_JAVA_SQL_TIME
 	case "DATE":


### PR DESCRIPTION
Druid returns column metadata type for double as Number [here](https://github.com/gorillio/rill-druid/blob/rill-master/sql/src/main/java/org/apache/druid/sql/avatica/AbstractDruidJdbcStatement.java#L178). This is used during row scanning to extract value using `v.NumberValue` [here](https://github.com/rilldata/calcite-avatica-go/blob/main/rows.go#L222) which return 0 even though the `TypedValue.Type` is `Rep_DOUBLE`.

Note - this is only needed until new druid driver is not released. More context [here](https://rilldata.slack.com/archives/C01190F1R1D/p1712928621468349?thread_ts=1712603418.109569&cid=C01190F1R1D)